### PR TITLE
chore(deps): introduce Renovate for automated dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["patch"],
+      "automerge": true,
+      "automergeType": "pr",
+      "groupName": "patch dependencies",
+      "groupSlug": "patch-dependencies"
+    },
+    {
+      "matchUpdateTypes": ["minor", "major"],
+      "automerge": false
+    }
+  ],
+  "dependencyDashboard": true,
+  "dependencyDashboardTitle": "Renovate Dependency Updates",
+  "schedule": ["before 10am on monday"],
+  "timezone": "America/New_York",
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 2
+}


### PR DESCRIPTION
### Changes
  - Add `renovate.json` matching the Combinaut org standard (weekly Monday schedule, patch auto-merge grouped, manual approval for minor/major, dependency dashboard enabled).

### Why

Completes the org-wide rollout of Renovate as the single dependency-update bot. Aligns this repo with `sparkle`, `hl7-message-router`, `combinaut-staging-infrastructure`, `match-mate`, `match-mate-server`, `sparkle-twilio-call-center`, `azure-alert-hub`, and `watchtower`.

### Test plan
  - After merge, Renovate should post an onboarding PR followed by the Dependency Dashboard issue within a few hours.

### Special Handling
  - [ ] This PR requires user testing
  - [ ] Include this PR in the changelog